### PR TITLE
Use pg.Pool instead of pg.Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@
 
 <sup>**Social Media Photo by [Hu Chen](https://unsplash.com/@huchenme) on [Unsplash](https://unsplash.com/)**</sup>
 
-A [10 LOC](https://github.com/WebReflection/pg-tag/blob/master/esm/index.js) utility to safely query [pg](https://www.npmjs.com/package/pg) via template literals.
+A [tiny](https://github.com/WebReflection/pg-tag/blob/master/esm/index.js) utility to safely query [pg](https://www.npmjs.com/package/pg) via template literals.
 
 ```js
-const {Client} = require('pg');
+const {Pool} = require('pg');
 
-const pg = require('pg-tag')(new Client);
-pg.client.connect();
+const pg = require('pg-tag')(new Pool);
 
 // returns result.rows[0]
 const user = await pg.get`
@@ -35,4 +34,9 @@ await pg.query`
   FROM users
   WHERE status = ${activeUser}
 `;
+
+// execute a query without sanitizing it
+await pg.raw`SELECT * FROM ${'users'}`;
+
+pg.pool.end();
 ```

--- a/cjs/index.js
+++ b/cjs/index.js
@@ -1,11 +1,12 @@
 'use strict';
-const uid = '🐘' + Date.now();
-const re = new RegExp(uid, 'g');
-const filled = (t, i = 1) =>
-  t.length === 1 ? t[0] : t.join(uid).replace(re, () => '$' + i++);
-module.exports = client => ({
-  client,  // exported to allow pg.client.connect()
-  all: (t, ...data) => client.query(filled(t), data).then($ => $.rows),
-  get: (t, ...data) => client.query(filled(t), data).then($ => $.rows.shift()),
-  query: (t, ...data) => client.query(filled(t), data)
+const uid = '🐘' + Date.now(), re = new RegExp(uid, 'g');
+const filled = (t, i) => t.join(uid).replace(re, () => '$' + i++);
+const query = (pool, t, data) => pool.connect().then(
+  client => client.query(t.length === 1 ? t[0] : filled(t, 1), data).then(
+    $ => (client.release(), $), _ => (client.release(), Promise.reject(_))));
+module.exports = pool => ({ pool, // in case it's needed to db.pool.end()
+  all: (t, ...data) => query(pool, t, data).then($ => $.rows),
+  get: (t, ...data) => query(pool, t, data).then($ => $.rows.shift()),
+  query: (t, ...data) => query(pool, t, data),
+  raw: (t, ...v) => query(pool, [t.reduce((p, c, i) => p + v[i - 1] + c)], [])
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pg-tag",
   "version": "0.1.3",
-  "description": "A 10 LOC utility to safely query pg via template literals.",
+  "description": "A tiny utility to safely query pg via template literals.",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,8 @@
 
 // example
 const pg = {
+  connect: () => Promise.resolve(pg),
+  release: () => {},
   query: (...args) => new Promise((resolve, reject) => {
     if (args[1].shift() === 'FAIL')
       reject();
@@ -9,14 +11,19 @@ const pg = {
   })
 };
 
-const {client, get, all, query} = require('.')(pg);
+const {pool, get, all, query, raw} = require('.')(pg);
 
-console.assert(client === pg, 'unexpected client');
+console.assert(pool === pg, 'unexpected pool');
 
 const exit = err => {
   console.log('✔ failure works: ' + !err);
   process.exit(!!err * 1);
 };
+
+raw`SELECT * FROM ${'users'}`.then(result => {
+  console.assert(result.rows.join(',') === '1,2,3', 'unexpected query result');
+  console.log('✔ raw works');
+});
 
 query`
   SELECT *


### PR DESCRIPTION
In order to improve concurrent connections and avoid
holding a connected client forever, this version uses
a pg.Pool instead, connecting each time, and releasing
the client after each query.